### PR TITLE
Fix kiosk blank screen after refresh

### DIFF
--- a/templates/kiosk.html
+++ b/templates/kiosk.html
@@ -211,19 +211,20 @@
             if (currentSlideIndex >= slides.length) {
                 currentSlideIndex = 0;
             }
+
+            // Ensure a slide is visible immediately after rebuilding
+            showCurrentSlide();
         }
-        
-        function cycleSlide() {
-            clearTimeout(slideTimeout);
+
+        function showCurrentSlide() {
             if (slides.length === 0) return;
 
             document.querySelectorAll('.slide.active').forEach(el => el.classList.remove('active'));
 
-            const current = slides[currentSlideIndex];
+            let current = slides[currentSlideIndex];
             if (!current) {
                 currentSlideIndex = 0;
-                cycleSlide();
-                return;
+                current = slides[0];
             }
 
             kioskHeader.style.display = current.isImage ? 'none' : 'flex';
@@ -237,13 +238,21 @@
             }
 
             slideEl.classList.add('active');
+        }
+        
+        function cycleSlide() {
+            clearTimeout(slideTimeout);
+            if (slides.length === 0) return;
+
+            showCurrentSlide();
 
             if (slides.length <= 1) return;
 
+            const current = slides[currentSlideIndex];
             const delaySec = current.isImage
                 ? (current.time || globalKioskConfig.kiosk_image_page_time || 5)
                 : (globalKioskConfig.kiosk_printer_page_time || 10);
-            
+
             currentSlideIndex = (currentSlideIndex + 1) % slides.length;
             slideTimeout = setTimeout(cycleSlide, delaySec * 1000);
         }


### PR DESCRIPTION
## Summary
- ensure kiosk slides are displayed immediately after refresh
- refactor slide cycling logic

## Testing
- `python -m py_compile aggregator_with_ui.py`
- `pip install flask requests werkzeug`

------
https://chatgpt.com/codex/tasks/task_e_6880e54c5eb08323ac302fb7ef08b3a9