### PR TITLE
Fix account dropdown links, admin visibility, filename permissions, user management, dashboard refresh updates, role-permission editing limits, add role-permission bulk toggles, allow configurable dashboard header image size and position, and support custom port with credentialed status fetches

### DIFF
--- a/aggregator_with_ui.py
+++ b/aggregator_with_ui.py
@@ -45,7 +45,7 @@ ASSETS_UPLOAD_FOLDER = os.path.join(BASE_DIR, 'static/assets')
 ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif', 'svg'}
 ALLOWED_GCODE_EXTENSIONS = {'gcode', 'g', 'gco'}
 CACHE_TTL = 5
-HTTP_PORT = 80
+HTTP_PORT = int(os.environ.get("HTTP_PORT", 80))
 
 # Add 'view_file_names' so we can gate filename visibility
 BASE_PERMISSIONS = [
@@ -68,7 +68,7 @@ def get_available_permissions():
     return BASE_PERMISSIONS + kiosk_perms
 
 app = Flask(__name__)
-CORS(app)
+CORS(app, supports_credentials=True)
 app.secret_key = 'a-very-secret-and-random-key-that-you-should-change'
 app.config['PRINTER_UPLOAD_FOLDER'] = PRINTER_UPLOAD_FOLDER
 app.config['KIOSK_UPLOAD_FOLDER'] = KIOSK_UPLOAD_FOLDER
@@ -105,6 +105,8 @@ def get_full_config():
     defaults = {
         "dashboard_title": "Printer Dashboard",
         "dashboard_title_image": "",
+        "dashboard_title_image_height": 40,
+        "dashboard_title_image_position": "left",
         "manual_statuses": ["Ready", "Printing", "Under Maintenance", "Offline"],
         "status_colors": {
             "ready": "#28a745", "idle": "#28a745", "operational": "#28a745",
@@ -300,7 +302,8 @@ def fetch_prusalink_data(p):
         return {'state': 'Config Error', 'error': 'Missing IP or API Key'}
     try:
         headers = {'X-Api-Key': p['api_key']}
-        resp = requests.get(f"http://{p['ip']}/api/v1/status", headers=headers, timeout=5)
+        base_url = f"http://{p['ip']}/api/v1"
+        resp = requests.get(f"{base_url}/status", headers=headers, timeout=5)
         resp.raise_for_status()
         status = resp.json()
         printer = status.get('printer', {}) or {}
@@ -309,10 +312,31 @@ def fetch_prusalink_data(p):
         file_obj = job_status.get('file', {}) if isinstance(job_status, dict) else {}
         filename = (file_obj.get('display_name') or file_obj.get('name') or
                     job_status.get('file_name') or job_status.get('filename') or file_obj.get('path'))
+
+        # If no filename was returned in the status response, try the dedicated job endpoint
+        if not filename:
+            try:
+                job_resp = requests.get(f"{base_url}/job", headers=headers, timeout=5)
+                job_resp.raise_for_status()
+                job_data = job_resp.json()
+                file_obj2 = job_data.get('file', {}) if isinstance(job_data, dict) else {}
+                filename = (file_obj2.get('display_name') or file_obj2.get('name') or
+                            job_data.get('file_name') or job_data.get('filename') or file_obj2.get('path'))
+            except Exception as e:
+                logging.debug(f"PrusaLink job fetch failed for '{p.get('name')}': {e}")
+
+        prog = job_status.get('progress')
+        if prog is not None:
+            try:
+                prog = float(prog)
+                prog = round(prog * 100, 1) if prog <= 1 else round(prog, 1)
+            except (ValueError, TypeError):
+                prog = None
+
         return {
             'state': state,
             'filename': filename,
-            'progress': int(job_status.get('progress')) if job_status.get('progress') is not None else None,
+            'progress': prog,
             'bed_temp': round(printer.get('temp_bed'), 1) if printer.get('temp_bed') is not None else None,
             'nozzle_temp': round(printer.get('temp_nozzle'), 1) if printer.get('temp_nozzle') is not None else None,
             'time_elapsed': int(job_status.get('time_printing')) if job_status.get('time_printing') is not None else None,
@@ -500,15 +524,30 @@ def status_json():
         config = get_full_config()
         overrides = load_data(OVERRIDES_FILE, {})
         aliases = config.get('status_aliases', {})
+
+        # Determine if current user has permission to view file names
+        roles = load_data(ROLES_FILE, {})
+        user_permissions = []
+        if 'username' in session:
+            user_role = session.get('role', '')
+            user_permissions = roles.get(user_role, {}).get('permissions', [])
+            if '*' in user_permissions:
+                user_permissions = get_available_permissions()
+        can_view_filenames = 'view_file_names' in user_permissions
+
         processed_data = {}
         for name, data in status_data.items():
-            processed_data[name] = data.copy()
+            processed = data.copy()
             if name in overrides and overrides[name].get('status'):
-                processed_data[name]['state'] = overrides[name]['status']
-            original_state = processed_data[name].get('state')
+                processed['state'] = overrides[name]['status']
+            original_state = processed.get('state')
             if original_state in aliases and aliases[original_state]:
-                processed_data[name]['state'] = aliases[original_state]
-        return jsonify({**processed_data, 'config': config})
+                processed['state'] = aliases[original_state]
+            if not can_view_filenames or not processed.get('show_filename', True):
+                processed['filename'] = None
+            processed_data[name] = processed
+
+        return jsonify({**processed_data, 'config': config, 'can_view_filenames': can_view_filenames})
     except Exception as e:
         logging.exception("status_json failed")
         return jsonify({"error": "status_unavailable"}), 500
@@ -528,6 +567,13 @@ def admin():
     user_permissions = roles.get(user_role_name, {}).get('permissions', [])
     if '*' in user_permissions:
         user_permissions = get_available_permissions()
+
+    can_manage_users = any(p in user_permissions for p in [
+        'add_user', 'edit_user', 'delete_user', 'change_user_password', 'change_user_role'
+    ])
+    can_manage_roles = any(p in user_permissions for p in [
+        'add_role', 'edit_role', 'delete_role'
+    ])
 
     # live statuses + all statuses for config UI
     live_statuses = fetch_all(printers)
@@ -604,6 +650,8 @@ def admin():
         permission_labels=permission_labels,
         log_content=log_content,
         user_permissions=user_permissions,
+        can_manage_users=can_manage_users,
+        can_manage_roles=can_manage_roles,
         active_tab=active_tab, selected_kiosk=selected_kiosk,
         pending_jobs=pending_jobs, live_statuses=live_statuses
     )
@@ -724,7 +772,7 @@ def manage_users():
 def add_user(active_tab):
     users = load_data(USERS_FILE, {})
     roles = load_data(ROLES_FILE, {})
-    logged_in_role_level = roles.get(session.get('role'), {}).get('level', 0)
+    logged_in_role_level = int(roles.get(session.get('role'), {}).get('level', 0))
     username = (request.form.get('username') or '').strip()
     password = request.form.get('password')
     role = request.form.get('role')
@@ -746,7 +794,7 @@ def add_user(active_tab):
                 flash('An account with that email already exists.', 'danger')
                 return redirect(url_for('admin', tab=active_tab))
 
-    if roles.get(role, {}).get('level', 999) >= logged_in_role_level and session.get('role') != 'system':
+    if int(roles.get(role, {}).get('level', 999)) >= logged_in_role_level and session.get('role') != 'system':
         flash('You cannot create a user with a role equal to or higher than your own.', 'danger')
     else:
         users[username] = {
@@ -803,9 +851,9 @@ def edit_user(active_tab):
 def delete_user(active_tab):
     users = load_data(USERS_FILE, {})
     roles = load_data(ROLES_FILE, {})
-    logged_in_role_level = roles.get(session.get('role'), {}).get('level', 0)
+    logged_in_role_level = int(roles.get(session.get('role'), {}).get('level', 0))
     username_to_delete = request.form.get('username')
-    if username_to_delete in users and roles.get(users[username_to_delete]['role'], {}).get('level', 999) < logged_in_role_level:
+    if username_to_delete in users and int(roles.get(users[username_to_delete]['role'], {}).get('level', 999)) < logged_in_role_level:
         del users[username_to_delete]
         save_data(users, USERS_FILE)
         flash(f"User '{username_to_delete}' deleted.", 'success')
@@ -833,8 +881,11 @@ def add_role(active_tab):
     role_name = (request.form.get('role_name') or '').lower().replace(' ', '_')
     permissions = request.form.getlist('permissions')
     level = int(request.form.get('level', 1))
+    user_role_name = session.get('role', '')
+    user_permissions = roles.get(user_role_name, {}).get('permissions', [])
     if role_name and role_name not in roles:
-        roles[role_name] = {'permissions': permissions, 'level': level}
+        allowed_perms = [p for p in permissions if p in user_permissions]
+        roles[role_name] = {'permissions': allowed_perms, 'level': level}
         save_data(roles, ROLES_FILE)
         flash(f"Role '{role_name}' created.", 'success')
     else:
@@ -863,7 +914,17 @@ def edit_role_post(active_tab):
         return redirect(url_for('admin', tab=active_tab))
     permissions = request.form.getlist('permissions')
     level = int(request.form.get('level', 1))
-    roles[role_name]['permissions'] = permissions
+    user_role_name = session.get('role', '')
+    user_permissions = set(roles.get(user_role_name, {}).get('permissions', []))
+    current_perms = set(role_to_edit.get('permissions', []))
+    final_perms = set(current_perms)
+    requested_perms = set(permissions)
+    for perm in user_permissions:
+        if perm in requested_perms:
+            final_perms.add(perm)
+        else:
+            final_perms.discard(perm)
+    roles[role_name]['permissions'] = sorted(final_perms)
     roles[role_name]['level'] = level
     save_data(roles, ROLES_FILE)
     flash(f"Role '{role_name}' updated.", 'success')
@@ -902,6 +963,8 @@ def update_appearance(active_tab):
             filename = secure_filename(f"title_logo_{file.filename}")
             file.save(os.path.join(app.config['ASSETS_UPLOAD_FOLDER'], filename))
             config['dashboard_title_image'] = url_for('static', filename=f"assets/{filename}")
+    config['dashboard_title_image_height'] = int(request.form.get('dashboard_title_image_height', config.get('dashboard_title_image_height', 40)))
+    config['dashboard_title_image_position'] = request.form.get('dashboard_title_image_position', config.get('dashboard_title_image_position', 'left'))
     config['card_size'] = request.form.get('card_size', 'medium')
     config['font_family'] = request.form.get('font_family', 'sans-serif')
     config['sort_by'] = request.form.get('sort_by', 'manual')
@@ -1341,7 +1404,7 @@ def register():
     return redirect(url_for('root'))
 
 # Alias so templates can use url_for('signup')
-@app.route('/signup', methods=['POST'])
+@app.route('/signup', methods=['POST'], endpoint='signup')
 def signup_alias():
     return register()
 

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -204,7 +204,7 @@
         </button>
       </li>
       {% endif %}
-      {% if 'add_user' in user_permissions %}
+      {% if can_manage_users or can_manage_roles %}
       <li class="nav-item" role="presentation">
         <button class="nav-link" id="users-tab" data-bs-toggle="tab" data-bs-target="#users-tab-pane" type="button" role="tab">Users / Roles</button>
       </li>
@@ -254,7 +254,7 @@
                           {% for printer in printers %}
                           <tr>
                             <td>{{ printer.name }}</td>
-                            <td>{{ printer.type }}</td>
+                            <td>{{ printer.type|capitalize }}</td>
                             <td>
                               {% if printer.type == 'prusa' %}{{ printer.ip }} / {{ printer.api_key[:4] }}...{% endif %}
                               {% if printer.type == 'klipper' %}{{ printer.url }}{% endif %}
@@ -398,6 +398,17 @@
                 <div class="col-md-4">
                   <label class="form-label">Upload Title Image</label>
                   <input type="file" name="dashboard_title_image_file" class="form-control" accept="image/*">
+                </div>
+                <div class="col-md-4">
+                  <label class="form-label">Title Image Height (px)</label>
+                  <input type="number" name="dashboard_title_image_height" value="{{ config.dashboard_title_image_height }}" class="form-control" min="10">
+                </div>
+                <div class="col-md-4">
+                  <label class="form-label">Title Image Position</label>
+                  <select name="dashboard_title_image_position" class="form-select">
+                    <option value="left" {% if config.dashboard_title_image_position != 'center' %}selected{% endif %}>Left</option>
+                    <option value="center" {% if config.dashboard_title_image_position == 'center' %}selected{% endif %}>Center</option>
+                  </select>
                 </div>
                 <div class="col-md-4">
                   <label class="form-label">Top Bar Color</label>
@@ -685,19 +696,19 @@
             <h5 class="card-title">Self Sign-up Settings</h5>
             <form action="{{ url_for('manage_config') }}" method="POST" class="row g-3 align-items-end">
               <input type="hidden" name="active_tab" value="user-role">
-              <input type="hidden" name="action" value="update_auth">
+              <input type="hidden" name="action" value="update_signup_settings">
               <div class="col-md-4">
                 <div class="form-check">
-                  <input class="form-check-input" type="checkbox" id="allow_signup" name="allow_self_signup" {% if config.allow_self_signup %}checked{% endif %}>
-                  <label class="form-check-label" for="allow_signup">Allow Self Sign-up</label>
+                  <input class="form-check-input" type="checkbox" id="enable_signup" name="enable_self_signup" {% if config.enable_self_signup %}checked{% endif %}>
+                  <label class="form-check-label" for="enable_signup">Allow Self Sign-up</label>
                 </div>
               </div>
               <div class="col-md-4">
-                <label class="form-label" for="default_role">Default Role for New Accounts</label>
-                <select class="form-select" id="default_role" name="default_role">
+                <label class="form-label" for="default_signup_role">Default Role for New Accounts</label>
+                <select class="form-select" id="default_signup_role" name="default_signup_role">
                   {% for role_name, role_data in roles.items() %}
-                    {% if roles[session.role].level > role_data.level %}
-                      <option value="{{ role_name }}" {% if config.default_role == role_name %}selected{% endif %}>{{ role_name }}</option>
+                    {% if roles.get(session.role, {}).get('level', 0)|int > role_data.level|int %}
+                      <option value="{{ role_name }}" {% if config.default_signup_role == role_name %}selected{% endif %}>{{ role_name }}</option>
                     {% endif %}
                   {% endfor %}
                 </select>
@@ -712,19 +723,24 @@
         <div class="card">
           <div class="card-body">
             <ul class="nav nav-pills mb-3" id="userRoleTab" role="tablist">
+              {% if can_manage_users %}
               <li class="nav-item" role="presentation">
-                <button class="nav-link active" id="manage-users-subtab" data-bs-toggle="tab" data-bs-target="#manage-users-pane" type="button">Users</button>
+                <button class="nav-link {% if can_manage_users %}active{% endif %}" id="manage-users-subtab" data-bs-toggle="tab" data-bs-target="#manage-users-pane" type="button">Users</button>
               </li>
+              {% endif %}
+              {% if can_manage_roles %}
               <li class="nav-item" role="presentation">
-                <button class="nav-link" id="manage-roles-subtab" data-bs-toggle="tab" data-bs-target="#manage-roles-pane" type="button">Roles</button>
+                <button class="nav-link {% if not can_manage_users %}active{% endif %}" id="manage-roles-subtab" data-bs-toggle="tab" data-bs-target="#manage-roles-pane" type="button">Roles</button>
               </li>
+              {% endif %}
             </ul>
 
             <div class="tab-content pt-3">
+              {% if can_manage_users %}
               <!-- Users -->
-              <div class="tab-pane fade show active" id="manage-users-pane">
+              <div class="tab-pane fade {% if can_manage_users %}show active{% endif %}" id="manage-users-pane">
                 <div class="row">
-                  <div class="col-lg-7">
+                  <div class="{{ 'col-lg-7' if 'add_user' in user_permissions else 'col-12' }}">
                     <div class="card mb-4">
                       <div class="card-body">
                         <h5 class="card-title">User Management</h5>
@@ -739,31 +755,37 @@
                                 <td>{{ data.get('email','') }}</td>
                                 <td>{{ data.role }}</td>
                                 <td class="d-flex gap-2 flex-wrap">
-                                  {% if session.role == 'system' or (roles[data.role].level < roles[session.role].level) %}
-                                  <button type="button" class="btn btn-sm btn-secondary edit-user-btn"
-                                          data-bs-toggle="modal" data-bs-target="#editUserModal"
-                                          data-user-username="{{ username }}"
-                                          data-user-name="{{ data.get('name','') }}"
-                                          data-user-email="{{ data.get('email','') }}"
-                                          data-user-role="{{ data.role }}">
-                                    Edit
-                                  </button>
+                                  {% if session.role == 'system' or (roles.get(data.role, {}).get('level', 0)|int < roles.get(session.role, {}).get('level', 0)|int) %}
+                                    {% if 'edit_user' in user_permissions %}
+                                    <button type="button" class="btn btn-sm btn-secondary edit-user-btn"
+                                            data-bs-toggle="modal" data-bs-target="#editUserModal"
+                                            data-user-username="{{ username }}"
+                                            data-user-name="{{ data.get('name','') }}"
+                                            data-user-email="{{ data.get('email','') }}"
+                                            data-user-role="{{ data.role }}">
+                                      Edit
+                                    </button>
+                                    {% endif %}
 
-                                  <button type="button" class="btn btn-sm btn-warning change-password-btn"
-                                          data-bs-toggle="modal" data-bs-target="#changePasswordModal"
-                                          data-user-username="{{ username }}"
-                                          data-user-name="{{ data.get('name','') }}"
-                                          data-user-email="{{ data.get('email','') }}"
-                                          data-user-role="{{ data.role }}">
-                                    Change Password
-                                  </button>
+                                    {% if 'change_user_password' in user_permissions %}
+                                    <button type="button" class="btn btn-sm btn-warning change-password-btn"
+                                            data-bs-toggle="modal" data-bs-target="#changePasswordModal"
+                                            data-user-username="{{ username }}"
+                                            data-user-name="{{ data.get('name','') }}"
+                                            data-user-email="{{ data.get('email','') }}"
+                                            data-user-role="{{ data.role }}">
+                                      Change Password
+                                    </button>
+                                    {% endif %}
 
-                                  <form action="{{ url_for('manage_users') }}" method="POST" onsubmit="return confirm('Delete this user?');" class="d-inline">
-                                    <input type="hidden" name="active_tab" value="user-role">
-                                    <input type="hidden" name="action" value="delete_user">
-                                    <input type="hidden" name="username" value="{{ username }}">
-                                    <button class="btn btn-sm btn-danger" type="submit">Delete</button>
-                                  </form>
+                                    {% if 'delete_user' in user_permissions %}
+                                    <form action="{{ url_for('manage_users') }}" method="POST" onsubmit="return confirm('Delete this user?');" class="d-inline">
+                                      <input type="hidden" name="active_tab" value="user-role">
+                                      <input type="hidden" name="action" value="delete_user">
+                                      <input type="hidden" name="username" value="{{ username }}">
+                                      <button class="btn btn-sm btn-danger" type="submit">Delete</button>
+                                    </form>
+                                    {% endif %}
                                   {% endif %}
                                 </td>
                               </tr>
@@ -775,6 +797,7 @@
                     </div>
                   </div>
 
+                  {% if 'add_user' in user_permissions %}
                   <div class="col-lg-5">
                     <div class="card mb-4">
                       <div class="card-body">
@@ -802,7 +825,7 @@
                             <label class="form-label">Role</label>
                             <select name="role" class="form-select">
                               {% for role_name, role_data in roles.items() %}
-                                {% if role_data.level < roles[session.role].level %}
+                                {% if role_data.level|int < roles.get(session.role, {}).get('level', 0)|int %}
                                   <option value="{{ role_name }}">{{ role_name }}</option>
                                 {% endif %}
                               {% endfor %}
@@ -813,12 +836,15 @@
                       </div>
                     </div>
                   </div>
+                  {% endif %}
 
                 </div>
               </div>
+              {% endif %}
 
+              {% if can_manage_roles %}
               <!-- Roles -->
-              <div class="tab-pane fade" id="manage-roles-pane">
+              <div class="tab-pane fade {% if not can_manage_users %}show active{% endif %}" id="manage-roles-pane">
                 <div class="card mb-4">
                   <div class="card-body">
                     <h5 class="card-title">Role Management</h5>
@@ -837,28 +863,30 @@
                             </td>
                             <td>
                               {% if role_name != 'system' %}
-                              <button type="button" class="btn btn-sm btn-secondary edit-role-btn"
-                                      data-bs-toggle="modal" data-bs-target="#editRoleModal"
-                                      data-role-name="{{ role_name }}"
-                                      data-role-level="{{ role_data.level }}"
-                                      data-role-perms='{{ role_data.permissions|tojson }}'>
-                                Edit
-                              </button>
+                                {% if 'edit_role' in user_permissions %}
+                                <button type="button" class="btn btn-sm btn-secondary edit-role-btn"
+                                        data-bs-toggle="modal" data-bs-target="#editRoleModal"
+                                        data-role-name="{{ role_name }}"
+                                        data-role-level="{{ role_data.level }}"
+                                        data-role-perms='{{ role_data.permissions|tojson }}'>
+                                  Edit
+                                </button>
+                                {% endif %}
 
-                              {% if role_name not in ['super_user','admin','intern'] %}
-                              <form action="{{ url_for('manage_roles') }}" method="POST" onsubmit="return confirm('Delete this role? This cannot be undone.');" class="d-inline">
-                                <input type="hidden" name="active_tab" value="user-role">
-                                <input type="hidden" name="action" value="delete_role">
-                                <input type="hidden" name="role_name" value="{{ role_name }}">
-                                <button class="btn btn-sm btn-danger" type="submit">Delete</button>
-                              </form>
-                              {% endif %}
+                                {% if role_name not in ['super_user','admin','intern'] and 'delete_role' in user_permissions %}
+                                <form action="{{ url_for('manage_roles') }}" method="POST" onsubmit="return confirm('Delete this role? This cannot be undone.');" class="d-inline">
+                                  <input type="hidden" name="active_tab" value="user-role">
+                                  <input type="hidden" name="action" value="delete_role">
+                                  <input type="hidden" name="role_name" value="{{ role_name }}">
+                                  <button class="btn btn-sm btn-danger" type="submit">Delete</button>
+                                </form>
+                                {% endif %}
 
-                              {% if session.get('original_role') in ['system','super_user'] or session.get('role') in ['system','super_user'] %}
-                              <form action="{{ url_for('login_as', role_name=role_name) }}" method="POST" class="d-inline">
-                                <button type="submit" class="btn btn-sm btn-info">Login As</button>
-                              </form>
-                              {% endif %}
+                                {% if session.get('original_role') in ['system','super_user'] or session.get('role') in ['system','super_user'] %}
+                                <form action="{{ url_for('login_as', role_name=role_name) }}" method="POST" class="d-inline">
+                                  <button type="submit" class="btn btn-sm btn-info">Login As</button>
+                                </form>
+                                {% endif %}
                               {% endif %}
                             </td>
                           </tr>
@@ -869,6 +897,7 @@
                   </div>
                 </div>
 
+                {% if 'add_role' in user_permissions %}
                 <div class="card">
                   <div class="card-body">
                     <h5 class="card-title">Create New Role</h5>
@@ -884,10 +913,14 @@
                         <input type="number" name="level" min="1" max="99" value="10" class="form-control" required>
                       </div>
                       <h6>Permissions:</h6>
-                      <div class="permissions-grid">
+                      <div class="mb-2">
+                        <button type="button" class="btn btn-sm btn-outline-primary me-2" id="add-role-add-all">Add All</button>
+                        <button type="button" class="btn btn-sm btn-outline-secondary" id="add-role-remove-all">Remove All</button>
+                      </div>
+                      <div class="permissions-grid" id="add-role-permissions">
                         {% for perm in available_permissions %}
                         <div class="form-check">
-                          <input class="form-check-input" type="checkbox" name="permissions" value="{{ perm }}" id="perm_{{ perm }}">
+                          <input class="form-check-input" type="checkbox" name="permissions" value="{{ perm }}" id="perm_{{ perm }}" {% if perm not in user_permissions %}disabled{% endif %}>
                           <label class="form-check-label" for="perm_{{ perm }}">{{ perm_names.get(perm, perm) }}</label>
                         </div>
                         {% endfor %}
@@ -896,8 +929,10 @@
                     </form>
                   </div>
                 </div>
+                {% endif %}
 
               </div><!-- /roles pane -->
+              {% endif %}
             </div>
           </div>
         </div>
@@ -1095,7 +1130,7 @@
                     <option value="{{ role_name }}">{{ role_name }}</option>
                   {% elif session.role == 'super_user' and role_name != 'system' %}
                     <option value="{{ role_name }}">{{ role_name }}</option>
-                  {% elif role_data.level < roles[session.role].level %}
+                  {% elif role_data.level|int < roles.get(session.role, {}).get('level', 0)|int %}
                     <option value="{{ role_name }}">{{ role_name }}</option>
                   {% endif %}
                 {% endfor %}
@@ -1244,10 +1279,14 @@
               </div>
               <div class="col-md-9">
                 <label class="form-label d-block">Permissions</label>
+                <div class="mb-2">
+                  <button type="button" class="btn btn-sm btn-outline-primary me-2" id="edit-role-add-all">Add All</button>
+                  <button type="button" class="btn btn-sm btn-outline-secondary" id="edit-role-remove-all">Remove All</button>
+                </div>
                 <div class="permissions-grid" id="edit-role-permissions">
                   {% for perm in available_permissions %}
                   <div class="form-check">
-                    <input class="form-check-input" type="checkbox" name="permissions" value="{{ perm }}" id="edit_perm_{{ perm }}">
+                    <input class="form-check-input" type="checkbox" name="permissions" value="{{ perm }}" id="edit_perm_{{ perm }}" {% if perm not in user_permissions %}disabled{% endif %}>
                     <label class="form-check-label" for="edit_perm_{{ perm }}">{{ perm_names.get(perm, perm) }}</label>
                   </div>
                   {% endfor %}
@@ -1446,6 +1485,48 @@
             }
           });
         }
+      }
+
+      /* ====== Edit Role Modal ====== */
+      const editRoleModal = document.getElementById('editRoleModal');
+      if (editRoleModal){
+        editRoleModal.addEventListener('show.bs.modal', function(event){
+          const b = event.relatedTarget;
+          const name = b.dataset.roleName || '';
+          const level = b.dataset.roleLevel || '';
+          const perms = JSON.parse(b.dataset.rolePerms || '[]');
+
+          editRoleModal.querySelector('#editRoleModalLabel').textContent = `Edit Role: ${name}`;
+          editRoleModal.querySelector('#edit-role-name').value = name;
+          editRoleModal.querySelector('#edit-role-level').value = level;
+
+          const permContainer = document.getElementById('edit-role-permissions');
+          if (permContainer){
+            permContainer.querySelectorAll('input[type="checkbox"]').forEach(cb => {
+              cb.checked = perms.includes(cb.value);
+            });
+          }
+        });
+      }
+
+      function togglePerms(container, checked){
+        container.querySelectorAll('input[type="checkbox"]:not(:disabled)').forEach(cb => { cb.checked = checked; });
+      }
+
+      const addRolePerms = document.getElementById('add-role-permissions');
+      const addRoleAddAll = document.getElementById('add-role-add-all');
+      const addRoleRemoveAll = document.getElementById('add-role-remove-all');
+      if (addRolePerms && addRoleAddAll && addRoleRemoveAll){
+        addRoleAddAll.addEventListener('click', () => togglePerms(addRolePerms, true));
+        addRoleRemoveAll.addEventListener('click', () => togglePerms(addRolePerms, false));
+      }
+
+      const editRolePerms = document.getElementById('edit-role-permissions');
+      const editRoleAddAll = document.getElementById('edit-role-add-all');
+      const editRoleRemoveAll = document.getElementById('edit-role-remove-all');
+      if (editRolePerms && editRoleAddAll && editRoleRemoveAll){
+        editRoleAddAll.addEventListener('click', () => togglePerms(editRolePerms, true));
+        editRoleRemoveAll.addEventListener('click', () => togglePerms(editRolePerms, false));
       }
 
       /* ====== Edit Printer Modal ====== */

--- a/templates/display.html
+++ b/templates/display.html
@@ -102,14 +102,15 @@
         }
 
         function fetchData() {
-            $.getJSON(`/status_json?kiosk=${kioskId}`)
-                .done(data => {
+            fetch(`/status_json?kiosk=${kioskId}`, {credentials:'include'})
+                .then(r=>{ if(!r.ok) throw new Error(); return r.json(); })
+                .then(data => {
                     if (data.kiosk_config) {
                         data.kiosk_config.kiosk_images = (data.kiosk_config.kiosk_images || []).filter(img => img.active !== false);
                         buildAndRenderSlides(data.kiosk_config);
                     }
                 })
-                .fail(() => {
+                .catch(() => {
                     console.error("Failed to fetch kiosk data update.");
                 });
         }

--- a/templates/kiosk.html
+++ b/templates/kiosk.html
@@ -258,15 +258,16 @@
         }
 
         function initialLoad() {
-            $.getJSON(statusEndpoint)
-                .done(data => {
+            fetch(statusEndpoint, {credentials:'include'})
+                .then(r=>{ if(!r.ok) throw new Error(); return r.json(); })
+                .then(data => {
                     buildAndRenderSlides(data);
                     const refreshInterval = (data.config?.refresh_interval_sec || 30) * 1000;
                     setInterval(() => {
-                        $.getJSON(statusEndpoint).done(buildAndRenderSlides);
+                        fetch(statusEndpoint, {credentials:'include'}).then(r=>r.json()).then(buildAndRenderSlides);
                     }, refreshInterval);
                 })
-                .fail(() => {
+                .catch(() => {
                     kioskContainer.innerHTML = '<h1 style="text-align:center; color: red; padding-top: 2rem;">Error fetching status. Retrying...</h1>';
                     setTimeout(initialLoad, 5000);
                 });

--- a/templates/public_dashboard.html
+++ b/templates/public_dashboard.html
@@ -35,6 +35,7 @@
       --shadow-color:rgba(0,0,0,.05);
       --skeleton-bg:#e9ecef;
       --top-bar-color: {{ config.top_bar_color|default('#007bff') }};
+      --title-image-height: {{ config.dashboard_title_image_height|default(40) }}px;
       color-scheme: light;
 
       --bs-body-bg: var(--bg-primary);
@@ -72,8 +73,11 @@
       display:flex; align-items:center; justify-content:space-between;
       gap: 1rem;
     }
+    .top-banner.center-title{justify-content:center;}
+    .top-banner.center-title .navbar-nav{position:absolute; right:30px; top:50%; transform:translateY(-50%);}
+    .top-banner.center-title .title{text-align:center;}
     .title{margin:0; font-size:1.6rem; font-weight:600; white-space:nowrap;}
-    .title-image{max-height:40px;}
+    .title-image{height:var(--title-image-height);}
     .navbar-nav{display:flex; align-items:center; gap:.75rem; flex-wrap:wrap;}
     .top-banner .nav-link{color:#fff; text-decoration:none; padding:5px 10px; border:1px solid rgba(255,255,255,.3); border-radius:5px;}
     .top-banner .nav-link:hover{background-color:rgba(255,255,255,.12);}
@@ -90,7 +94,7 @@
     .summary-inner{ padding:.85rem 1rem; }
     .stats-grid{
       display:grid;
-      grid-template-columns: repeat(auto-fill,minmax(140px,1fr));
+      grid-template-columns: repeat(auto-fit,minmax(140px,1fr));
       gap: .75rem;
       width:100%;
     }
@@ -114,8 +118,11 @@
     /* Cards grid */
     #dash{
       display:grid;
-      grid-template-columns: repeat(auto-fill,minmax(320px,1fr));
       gap: 20px;
+      grid-template-columns: repeat(auto-fit,minmax(320px,1fr));
+    }
+    @media (min-width: 960px){
+      #dash{ grid-template-columns: repeat(3,1fr); }
     }
 
     /* Printer card */
@@ -168,8 +175,14 @@
     .filename-line{
       font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
       font-size:.9rem;
-      color: var(--text-secondary);
+      color: var(--text-primary);
       white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+
+    .filename-line code{
+      color: inherit;
+      background: transparent;
+      padding:0;
     }
 
     /* Status / progress */
@@ -216,7 +229,7 @@
   data-user-can-upload="{{ ('upload_gcode' in user_permissions)|tojson }}"
   data-user-can-view-filenames="{{ user_can_view_filenames|tojson }}"
 >
-  <nav class="top-banner">
+  <nav class="top-banner{% if config.dashboard_title_image_position == 'center' %} center-title{% endif %}">
     <div class="title">
       {% if config.dashboard_title_image %}
         <img src="{{ config.dashboard_title_image }}" alt="{{ dashboard_title }}" class="title-image">
@@ -232,7 +245,10 @@
             Welcome, <strong>{{ session.username }}</strong>
           </button>
           <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
+            <li><a class="dropdown-item" href="{{ url_for('manage_account') }}">My Account</a></li>
+            {% if 'admin_panel_access' in user_permissions %}
             <li><a class="dropdown-item" href="{{ url_for('admin') }}">Admin Panel</a></li>
+            {% endif %}
             <li><a class="dropdown-item" href="{{ url_for('logout') }}">Logout</a></li>
           </ul>
         </div>
@@ -316,7 +332,7 @@
             <div class="tab-pane fade {% if open_signup_modal %}show active{% endif %}" id="signup-pane" role="tabpanel">
               {% set errs = signup_errors or {} %}
               {% set vals = signup_values or {} %}
-              <form action="{{ url_for('register') }}" method="POST" novalidate>
+              <form action="{{ url_for('signup') }}" method="POST" novalidate>
                 <div class="mb-3">
                   <label class="form-label">Username</label>
                   <input type="text" name="username" class="form-control {% if errs.get('username') %}is-invalid{% endif %}"
@@ -429,6 +445,7 @@
     }
 
     let refreshTimeout;
+    let firstLoad = true;
 
     function colorKey(str){ return String(str || '').toLowerCase().replace(/\s+/g,'_'); }
     function resolveImageSrc(p){
@@ -602,11 +619,16 @@
     }
     window.addEventListener('resize', () => { clearTimeout(window.__eqT); window.__eqT = setTimeout(equalizeCardHeights, 100); });
 
-    function render(data){
+    function render(data, initial){
       try{
         const dash = $('#dash');
         const config = data.config || {};
-        const printerData = { ...data }; delete printerData.config;
+        const userCanViewNames = (typeof data.can_view_filenames === 'boolean')
+          ? data.can_view_filenames
+          : (document.body.dataset.userCanViewFilenames === 'true');
+        const printerData = { ...data };
+        delete printerData.config;
+        delete printerData.can_view_filenames;
         let printerArray = Object.entries(printerData);
 
         if (config.sort_by === 'status'){
@@ -624,22 +646,32 @@
 
         updateStatsFromArray(printerArray, config);
 
-        dash.empty();
+        const userCanUpload = document.body.dataset.userCanUpload === 'true';
+
+        const existing = new Map(Array.from(document.querySelectorAll('.printer-card')).map(card => [card.dataset.printerName, card]));
+
+        if (initial) dash.empty();
         if (!printerArray.length){
           dash.html('<div class="col-12"><p class="text-center">No printers found. Please add one in the Admin Panel.</p></div>');
           return;
         }
-        const userCanUpload = document.body.dataset.userCanUpload === 'true';
-        const userCanViewNames = document.body.dataset.userCanViewFilenames === 'true';
 
-        const frag = document.createDocumentFragment();
         for (const [name, p] of printerArray){
           const html = createPrinterCardHTML(name, p, config, userCanUpload, userCanViewNames);
           const wrap = document.createElement('div');
           wrap.innerHTML = html.trim();
-          frag.appendChild(wrap.firstElementChild);
+          const newCard = wrap.firstElementChild;
+          const oldCard = existing.get(name);
+          if (oldCard){
+            oldCard.replaceWith(newCard);
+            existing.delete(name);
+          } else {
+            document.getElementById('dash').appendChild(newCard);
+          }
         }
-        document.getElementById('dash').appendChild(frag);
+
+        // Remove cards for printers no longer present
+        for (const card of existing.values()) card.remove();
 
         equalizeCardHeights();
       } catch(err){
@@ -649,15 +681,19 @@
     }
 
     function fetchAndRender(){
-      $.getJSON('/status_json')
-        .done(data=>{
+      fetch('/status_json', {credentials:'include'})
+        .then(r=>{ if(!r.ok) throw new Error(); return r.json(); })
+        .then(data=>{
           const refreshInterval = (data.config && data.config.refresh_interval_sec) ? data.config.refresh_interval_sec*1000 : 30000;
-          render(data);
+          render(data, firstLoad);
+          firstLoad = false;
           clearTimeout(refreshTimeout);
           refreshTimeout = setTimeout(fetchAndRender, refreshInterval);
         })
-        .fail(()=>{
-          $('#dash').html('<p class="text-center text-danger">Failed to fetch printer status. Retrying in 30 seconds…</p>');
+        .catch(()=>{
+          if (firstLoad){
+            $('#dash').html('<p class="text-center text-danger">Failed to fetch printer status. Retrying in 30 seconds…</p>');
+          }
           clearTimeout(refreshTimeout);
           refreshTimeout = setTimeout(fetchAndRender, 30000);
         });

--- a/templates/status_page.html
+++ b/templates/status_page.html
@@ -90,14 +90,15 @@
             }
             
             function fetchAndRender() {
-                $.getJSON('/status_json')
-                    .done(data => {
+                fetch('/status_json', {credentials:'include'})
+                    .then(r=>{ if(!r.ok) throw new Error(); return r.json(); })
+                    .then(data => {
                         const refreshInterval = (data.config.refresh_interval_sec || 30) * 1000;
                         render(data);
                         clearTimeout(refreshTimeout);
                         refreshTimeout = setTimeout(fetchAndRender, refreshInterval);
                     })
-                    .fail(() => {
+                    .catch(() => {
                         clearTimeout(refreshTimeout);
                         refreshTimeout = setTimeout(fetchAndRender, 30000); // Retry after 30s on failure
                     });


### PR DESCRIPTION
## Summary
- Theme filename lines on the public dashboard so job names use standard text color
- Guard admin user-management role comparisons with safe lookups to prevent template errors for non-system accounts
- Point the public dashboard's My Account dropdown item to the correct `manage_account` endpoint to resolve Flask BuildError
- Hide the Admin Panel dropdown item unless the current user has `admin_panel_access`
- Remove job filenames from `/status_json` unless the user has `view_file_names` and the printer enables filename display
- Include a `can_view_filenames` flag in `/status_json` and let the dashboard honor it so authorized users see job filenames
- Add fallback `job` endpoint lookup and progress normalization for PrusaLink printers when filenames aren't returned by the `status` endpoint
- Restrict the public dashboard's printer-card grid to a maximum of three columns so cards wrap after three per row
- Refresh public dashboard data on a timer and update existing cards in place to avoid repeated loading animations
- Expose Users/Roles admin tabs and action buttons only when the viewer has matching permissions so non-admin roles can manage accounts within their rights
- Prevent role editors from granting or revoking permissions they don't themselves possess and disable unauthorized permission checkboxes in the admin UI
- Wire self-signup settings across admin and public pages and expose `/signup` endpoint
- Add a "My Account" dropdown link and responsive status cards on the public dashboard
- Add bulk add/remove permission buttons to role forms and pre-populate the edit-role modal with the role's current data
- Capitalize printer type names in the admin printer list
- Cast role-level comparisons to integers in both backend and admin template so authorized non-system roles see user-management action buttons
- Allow admins to configure the dashboard header image height and choose left or centered placement
- Expose `HTTP_PORT` env var and enable credentialed status requests so dashboards on alternate ports (e.g. 8080) still load printer data

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_68a34aa45bd883239524ccc2fdfbccab