### PR TITLE
feat: allow kiosk-specific text sizing

### DIFF
--- a/aggregator_with_ui.py
+++ b/aggregator_with_ui.py
@@ -996,6 +996,7 @@ def update_appearance(active_tab):
 def update_kiosk(active_tab):
     kiosk_id = request.form.get('kiosk_id', 'default')
     kiosk_config = get_kiosk_config(kiosk_id)
+    base_config = get_full_config()
     kiosk_specific_dir = os.path.join(app.config['KIOSK_UPLOAD_FOLDER'], kiosk_id)
     os.makedirs(kiosk_specific_dir, exist_ok=True)
     if kiosk_config.get('show_printers'):
@@ -1006,6 +1007,11 @@ def update_kiosk(active_tab):
         kiosk_config['kiosk_sort_by'] = request.form.get('kiosk_sort_by', 'manual')
         kiosk_config['kiosk_title'] = request.form.get('kiosk_title', '')
         kiosk_config['kiosk_header_height_px'] = int(request.form.get('kiosk_header_height_px', 150))
+        kiosk_config['font_size_printer_name_px'] = int(request.form.get('font_size_printer_name_px', base_config.get('font_size_printer_name_px', 20)))
+        kiosk_config['font_size_filename_px'] = int(request.form.get('font_size_filename_px', base_config.get('font_size_filename_px', 14)))
+        kiosk_config['font_size_status_px'] = int(request.form.get('font_size_status_px', base_config.get('font_size_status_px', 12)))
+        kiosk_config['font_size_details_px'] = int(request.form.get('font_size_details_px', base_config.get('font_size_details_px', 14)))
+        kiosk_config['progress_bar_font_size_px'] = int(request.form.get('progress_bar_font_size_px', base_config.get('progress_bar_font_size_px', 12)))
         if 'kiosk_header_image_file' in request.files:
             file = request.files['kiosk_header_image_file']
             if file and file.filename and allowed_file(file.filename):

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -278,6 +278,9 @@
                                 data-printer-url="{{ printer.get('url','') }}"
                                 data-printer-ip="{{ printer.get('ip','') }}"
                                 data-printer-api_key="{{ printer.get('api_key','') }}"
+                                data-printer-mainboard_id="{{ printer.get('mainboard_id','') }}"
+                                data-printer-mqtt_host="{{ printer.get('mqtt_host','') }}"
+                                data-printer-mqtt_port="{{ printer.get('mqtt_port','') }}"
                                 data-printer-image_url="{{ printer.get('image_url','') }}"
                                 data-printer-image_file="{{ printer.get('local_image_filename','') }}"
                                 data-printer-show_filename="{{ printer.get('show_filename', true)|tojson }}"
@@ -322,6 +325,7 @@
                           <select name="type" id="add-printer-type" class="form-select">
                             <option value="prusa">Prusa</option>
                             <option value="klipper">Klipper</option>
+                            <option value="centauri">Centauri Carbon</option>
                           </select>
                         </div>
                       </div>
@@ -341,6 +345,25 @@
                         <div class="col-12">
                           <label class="form-label">Moonraker/Klipper URL</label>
                           <input type="text" name="url" class="form-control" placeholder="http://klipper.local">
+                        </div>
+                      </div>
+
+                      <div id="centauri-fields" class="row g-3 mt-1 type-specific-fields" style="display:none;">
+                        <div class="col-md-6">
+                          <label class="form-label">IP Address</label>
+                          <input type="text" name="ip" class="form-control">
+                        </div>
+                        <div class="col-md-6">
+                          <label class="form-label">Mainboard ID</label>
+                          <input type="text" name="mainboard_id" class="form-control">
+                        </div>
+                        <div class="col-md-6">
+                          <label class="form-label">MQTT Host (Optional)</label>
+                          <input type="text" name="mqtt_host" class="form-control" placeholder="defaults to IP">
+                        </div>
+                        <div class="col-md-6">
+                          <label class="form-label">MQTT Port (Optional)</label>
+                          <input type="number" name="mqtt_port" class="form-control" placeholder="1883">
                         </div>
                       </div>
 
@@ -1198,10 +1221,11 @@
                 <select name="type" id="edit-printer-type" class="form-select">
                   <option value="prusa">Prusa</option>
                   <option value="klipper">Klipper</option>
+                  <option value="centauri">Centauri Carbon</option>
                 </select>
               </div>
 
-              <div class="col-md-6 edit-type-prusa">
+              <div class="col-md-6 edit-type-prusa edit-type-centauri">
                 <label class="form-label">IP Address</label>
                 <input type="text" class="form-control" id="edit-printer-ip" name="ip">
               </div>
@@ -1213,6 +1237,19 @@
               <div class="col-12 edit-type-klipper">
                 <label class="form-label">Moonraker/Klipper URL</label>
                 <input type="text" class="form-control" id="edit-printer-url" name="url" placeholder="http://klipper.local">
+              </div>
+
+              <div class="col-md-6 edit-type-centauri">
+                <label class="form-label">Mainboard ID</label>
+                <input type="text" class="form-control" id="edit-printer-mainboard_id" name="mainboard_id">
+              </div>
+              <div class="col-md-6 edit-type-centauri">
+                <label class="form-label">MQTT Host (Optional)</label>
+                <input type="text" class="form-control" id="edit-printer-mqtt_host" name="mqtt_host" placeholder="defaults to IP">
+              </div>
+              <div class="col-md-6 edit-type-centauri">
+                <label class="form-label">MQTT Port (Optional)</label>
+                <input type="number" class="form-control" id="edit-printer-mqtt_port" name="mqtt_port" placeholder="1883">
               </div>
 
               <div class="col-md-6">
@@ -1335,6 +1372,7 @@
       const type = document.getElementById('add-printer-type').value;
       document.getElementById('prusa-fields').style.display   = (type === 'prusa')  ? 'flex' : 'none';
       document.getElementById('klipper-fields').style.display = (type === 'klipper')? 'flex' : 'none';
+      document.getElementById('centauri-fields').style.display = (type === 'centauri')? 'flex' : 'none';
     }
     function displayKioskSettings(kid){
       document.querySelectorAll('.kiosk-settings').forEach(div => div.style.display = 'none');
@@ -1534,6 +1572,7 @@
         const type = document.getElementById('edit-printer-type').value;
         document.querySelectorAll('.edit-type-prusa').forEach(el => el.style.display = (type === 'prusa')? '' : 'none');
         document.querySelectorAll('.edit-type-klipper').forEach(el => el.style.display = (type === 'klipper')? '' : 'none');
+        document.querySelectorAll('.edit-type-centauri').forEach(el => el.style.display = (type === 'centauri')? '' : 'none');
       }
       if (editPrinterModal){
         editPrinterModal.addEventListener('show.bs.modal', function(event){
@@ -1543,6 +1582,9 @@
           const url  = b.dataset.printerUrl || '';
           const ip   = b.dataset.printerIp || '';
           const key  = b.dataset.printerApi_key || '';
+          const mbid = b.dataset.printerMainboard_id || '';
+          const mhost = b.dataset.printerMqtt_host || '';
+          const mport = b.dataset.printerMqtt_port || '';
           const imgU = b.dataset.printerImage_url || '';
           const showFilename = (b.dataset.printerShow_filename === 'true');
           const acceptsUploads = (b.dataset.printerAccepts_uploads === 'true');
@@ -1553,6 +1595,9 @@
           editPrinterModal.querySelector('#edit-printer-url').value = url;
           editPrinterModal.querySelector('#edit-printer-ip').value = ip;
           editPrinterModal.querySelector('#edit-printer-api_key').value = key;
+          editPrinterModal.querySelector('#edit-printer-mainboard_id').value = mbid;
+          editPrinterModal.querySelector('#edit-printer-mqtt_host').value = mhost;
+          editPrinterModal.querySelector('#edit-printer-mqtt_port').value = mport;
           editPrinterModal.querySelector('#edit-printer-image_url').value = imgU;
           editPrinterModal.querySelector('#edit-printer-show_filename').checked = showFilename;
           editPrinterModal.querySelector('#edit-printer-accepts_uploads').checked = acceptsUploads;

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -349,6 +349,11 @@
                       </div>
 
                       <div id="centauri-fields" class="row g-3 mt-1 type-specific-fields" style="display:none;">
+                        <div class="col-12">
+                          <span class="text-muted" data-bs-toggle="tooltip" title="Use the printer's web interface: IP is under Network settings, Mainboard ID under About. MQTT host defaults to that IP and port 1883.">
+                            <i class="bi bi-question-circle-fill"></i> Where to find these values?
+                          </span>
+                        </div>
                         <div class="col-md-6">
                           <label class="form-label">IP Address</label>
                           <input type="text" name="ip" class="form-control">
@@ -1225,6 +1230,12 @@
                 </select>
               </div>
 
+              <div class="col-12 edit-type-centauri">
+                <span class="text-muted" data-bs-toggle="tooltip" title="Use the printer's web interface: IP is under Network settings, Mainboard ID under About. MQTT host defaults to that IP and port 1883.">
+                  <i class="bi bi-question-circle-fill"></i> Where to find these values?
+                </span>
+              </div>
+
               <div class="col-md-6 edit-type-prusa edit-type-centauri">
                 <label class="form-label">IP Address</label>
                 <input type="text" class="form-control" id="edit-printer-ip" name="ip">
@@ -1402,6 +1413,10 @@
     document.addEventListener('DOMContentLoaded', function(){
       initializeTheme();
       setupLogAutoscroll();
+
+      document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => {
+        new bootstrap.Tooltip(el);
+      });
 
       // Deep-link tab by ?tab=...
       const urlParams = new URLSearchParams(window.location.search);

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1029,6 +1029,11 @@
                       <option value="status" {% if kconf.kiosk_sort_by == 'status' %}selected{% endif %}>Status</option>
                     </select>
                   </div>
+                  <div class="col-md-4"><label class="form-label">Printer Name Font Size (px)</label><input type="number" name="font_size_printer_name_px" value="{{ kconf.font_size_printer_name_px | default(config.font_size_printer_name_px | default(20)) }}" class="form-control" min="1"></div>
+                  <div class="col-md-4"><label class="form-label">Filename Font Size (px)</label><input type="number" name="font_size_filename_px" value="{{ kconf.font_size_filename_px | default(config.font_size_filename_px | default(14)) }}" class="form-control" min="1"></div>
+                  <div class="col-md-4"><label class="form-label">Status Font Size (px)</label><input type="number" name="font_size_status_px" value="{{ kconf.font_size_status_px | default(config.font_size_status_px | default(12)) }}" class="form-control" min="1"></div>
+                  <div class="col-md-4"><label class="form-label">Details Font Size (px)</label><input type="number" name="font_size_details_px" value="{{ kconf.font_size_details_px | default(config.font_size_details_px | default(14)) }}" class="form-control" min="1"></div>
+                  <div class="col-md-4"><label class="form-label">Progress Bar Font Size (px)</label><input type="number" name="progress_bar_font_size_px" value="{{ kconf.progress_bar_font_size_px | default(config.progress_bar_font_size_px | default(12)) }}" class="form-control" min="1"></div>
                   <div class="col-md-4"><label class="form-label">Header Height (px)</label><input type="number" name="kiosk_header_height_px" value="{{ kconf.kiosk_header_height_px }}" class="form-control" min="10"></div>
                   <div class="col-md-6"><label class="form-label">Header Title</label><input type="text" name="kiosk_title" value="{{ kconf.kiosk_title }}" class="form-control"></div>
                   <div class="col-md-6"><label class="form-label">Header Image</label><input type="file" name="kiosk_header_image_file" class="form-control" accept="image/*"></div>

--- a/templates/kiosk.html
+++ b/templates/kiosk.html
@@ -206,7 +206,8 @@
 
       let filenameHtml = '';
       if (p.show_filename && canViewNames && p.filename){
-        filenameHtml = `<div class="filename-line"><i class="bi bi-file-earmark-code"></i> <code>${p.filename}</code></div>`;
+        const fnSize = config.font_size_filename_px || 14;
+        filenameHtml = `<div class="filename-line" style="font-size:${fnSize}px;"><i class="bi bi-file-earmark-code"></i> <code>${p.filename}</code></div>`;
       }
 
       const badgeColor        = (config.status_colors && config.status_colors[colorKey(displayState)]) || '#6c757d';
@@ -214,9 +215,10 @@
       const progressBarColor  = config.progress_bar_color || '#0d6efd';
       const progressTextColor = config.progress_bar_text_color || 'var(--card-text)';
 
+      const statusFont = config.font_size_status_px || 12;
       let stateProgressHtml = `
         <div class="state-row">
-          <span class="state-badge" style="background:${badgeColor}; color:${badgeTextColor}">${displayState}</span>
+          <span class="state-badge" style="background:${badgeColor}; color:${badgeTextColor}; font-size:${statusFont}px;">${displayState}</span>
       `;
 
       if ((displayState === 'Printing' || displayState === 'Paused') && progressPct !== null){
@@ -224,8 +226,8 @@
           <div class="progress-bar-container" role="progressbar" aria-valuenow="${progressPct}" aria-valuemin="0" aria-valuemax="100">
             <div class="progress-fill" style="width:${progressPct}%; background:${progressBarColor};"></div>
           </div>
-          <div class="progress-percent" style="color:${progressTextColor}">${progressPct}%</div>
-          <div class="d-flex justify-content-between text-muted small">
+          <div class="progress-percent" style="color:${progressTextColor}; font-size:${config.progress_bar_font_size_px || statusFont}px;">${progressPct}%</div>
+          <div class="d-flex justify-content-between text-muted small" style="font-size:${config.font_size_details_px || 14}px;">
             <span><i class="bi bi-stopwatch"></i> Elapsed: ${formatTime(p.time_elapsed)}</span>
             <span><i class="bi bi-hourglass-split"></i> Remaining: ${formatTime(p.time_remaining)}</span>
           </div>
@@ -234,7 +236,7 @@
       stateProgressHtml += `</div>`;
 
       const tempsHtml = `
-        <div class="temps">
+        <div class="temps" style="font-size:${config.font_size_details_px || 14}px;">
           <div>
             <div class="label"><i class="bi bi-thermometer-half"></i> Nozzle</div>
             <div class="value">${nozzleTemp}</div>
@@ -251,7 +253,7 @@
         <div class="${cardClass}" data-printer-name="${name}" style="border-color:${badgeColor}">
           <div class="card-body">
             <div class="printer-header">
-              <h3><span class="status-indicator ${stateClass}"></span> ${name}</h3>
+              <h3 style="font-size:${config.font_size_printer_name_px || 20}px;"><span class="status-indicator ${stateClass}"></span> ${name}</h3>
               <span class="badge bg-secondary">${p.type || 'N/A'}</span>
             </div>
             <div class="image-slot">
@@ -358,7 +360,8 @@
           slideDiv.style.gridTemplateColumns = gridCols;
 
           slideData.printers.forEach(([name, pData]) => {
-            slideDiv.innerHTML += createPrinterCardHtml(name, pData, globalConfig, userCanViewNames);
+            const mergedConfig = Object.assign({}, globalConfig, globalKioskConfig);
+            slideDiv.innerHTML += createPrinterCardHtml(name, pData, mergedConfig, userCanViewNames);
           });
         }
         kioskContainer.appendChild(slideDiv);


### PR DESCRIPTION
## Summary
- allow per-kiosk font sizes to be configured in admin panel
- store kiosk font choices and apply them in kiosk display rendering

## Testing
- `python -m py_compile aggregator_with_ui.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4b8c173b0832388e0f32f5d886a19